### PR TITLE
chore: update @types/node to 18.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@angular/cli": "^18.2.20",
     "@angular/compiler-cli": "~18.2.13",
     "@types/jasmine": "~5.1.0",
-    "@types/node": "^12.11.1",
+    "@types/node": "^18.19.0",
     "jasmine-core": "~5.1.1",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.1.0",


### PR DESCRIPTION
## Summary
- bump the @types/node dev dependency to ^18.19.0 to align with Angular 18 requirements
- reinstall npm dependencies to pick up the new type definitions

## Testing
- npx ng version
- CI=1 npx ng build


------
https://chatgpt.com/codex/tasks/task_e_68da471c92d4833383bb1051c866e5da