### PR TITLE
Remove Popper direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@fullcalendar/daygrid": "^6.1.19",
     "@fullcalendar/interaction": "^6.1.19",
     "@ng-bootstrap/ng-bootstrap": "^17.0.1",
-    "@popperjs/core": "^2.11.8",
     "@swimlane/ngx-charts": "^20.5.0",
     "bootstrap": "^5.3.8",
     "d3": "^7.9.0",


### PR DESCRIPTION
## Summary
- remove the direct @popperjs/core dependency from package.json
- run npm install so the generated lockfile reflects the trimmed dependency set

## Testing
- CI=true npx ng serve --host 0.0.0.0 --port 4200


------
https://chatgpt.com/codex/tasks/task_e_68da4d513b748333bd2557c103333785