### PR TITLE
Remove direct d3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@ng-bootstrap/ng-bootstrap": "^17.0.1",
     "@swimlane/ngx-charts": "^20.5.0",
     "bootstrap": "^5.3.8",
-    "d3": "^7.9.0",
     "echarts": "^5.2.2",
     "ngx-echarts": "^8.0.1",
     "pdfmake": "^0.2.2",


### PR DESCRIPTION
## Summary
- remove the direct d3 dependency from package.json so ngx-charts can rely on its bundled requirements

## Testing
- npm install
- CI=1 npx ng build --configuration development --progress false

------
https://chatgpt.com/codex/tasks/task_e_68da4fbf378883338ddcae713eaa7a85