### PR TITLE
Add Popper dependency to resolve Bootstrap peer warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@fullcalendar/interaction": "^6.1.19",
     "@ng-bootstrap/ng-bootstrap": "^17.0.1",
     "@swimlane/ngx-charts": "^20.5.0",
+    "@popperjs/core": "^2.11.8",
     "bootstrap": "^5.3.8",
     "pdfmake": "^0.2.2",
     "rxjs": "~7.8",


### PR DESCRIPTION
## Summary
- add @popperjs/core to the project dependencies alongside Bootstrap to satisfy its peer requirement
- update installed packages so the dependency tree reflects the new Popper entry
- verify the Angular dev server still builds successfully with Bootstrap-driven components

## Testing
- npm install
- npm run start -- --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_68da5dcb9f84833384a593dd7f5953ba