### PR TITLE
Fix D3 load order for C3 charts

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -38,8 +38,8 @@
   <script src="assets/vendor/charts/morris-bundle/raphael.min.js"></script>
   <script src="assets/vendor/charts/morris-bundle/morris.js"></script>
   <!-- chart c3 js -->
-  <script src="assets/vendor/charts/c3charts/c3.min.js"></script>
   <script src="assets/vendor/charts/c3charts/d3-5.4.0.min.js"></script>
+  <script src="assets/vendor/charts/c3charts/c3.min.js"></script>
   <script src="assets/vendor/charts/c3charts/C3chartjs.js"></script>
   <!-- <script src="assets/libs/js/dashboard-ecommerce.js"></script> -->
 <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAXnbecxeD3a3ARzEU1_xdG8htGM4sVxuo" defer></script>


### PR DESCRIPTION
## Summary
- ensure d3 is loaded before c3 so global API is available to C3chartjs

## Testing
- npx ng serve --port 4400 --host 0.0.0.0 > serve.log 2>&1 &
- curl --max-time 5 -I http://localhost:4400/
- (browser) inspected console logs via Playwright to confirm absence of "d3 is not defined"


------
https://chatgpt.com/codex/tasks/task_e_68da5f20826883339cc6e47c74af5578