### PR TITLE
Add FullCalendar CSS to Angular build configuration

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -32,6 +32,8 @@
             "styles": [
               "./node_modules/bootstrap/dist/css/bootstrap.min.css",
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
+              "./node_modules/@fullcalendar/core/index.css",
+              "./node_modules/@fullcalendar/daygrid/index.css",
               "src/styles.css"
             ],
             "scripts": [


### PR DESCRIPTION
## Summary
- restore the FullCalendar core and daygrid CSS assets to the main Angular build styles array so the calendar renders correctly.

## Testing
- ng serve --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_68da630a09848333a343bcc1de2afc93