### PR TITLE
Remove unused modal dependencies from gestionar cliente component

### DIFF
--- a/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.ts
+++ b/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.ts
@@ -1,12 +1,9 @@
 import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
-import { ProyectoService } from 'src/app/control-panel/gestionar-proyecto/service/proyecto.service';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { Cliente } from './model/cliente.model';
 import { ClienteService } from './service/cliente.service';
-import { NgbModal, ModalDismissReasons } from '@ng-bootstrap/ng-bootstrap';
-import { NgForm } from '@angular/forms';
 @Component({
   selector: 'app-gestionar-cliente',
   templateUrl: './gestionar-cliente.component.html',
@@ -32,8 +29,7 @@ export class GestionarClienteComponent implements OnInit {
   @ViewChild(MatSort) matSort!: MatSort;
 
   constructor(
-    public service: ClienteService,
-    private modalService: NgbModal
+    public service: ClienteService
   ) { }
   fechaActual = '';
   async ngOnInit() {
@@ -55,19 +51,6 @@ export class GestionarClienteComponent implements OnInit {
       this.dataSource.paginator.firstPage();
     }
   }
-  //DESDE AQUI BORRAS
-  closeResult = '';
-
-  private getDismissReason(reason: any): string {
-    if (reason === ModalDismissReasons.ESC) {
-      return 'by pressing ESC';
-    } else if (reason === ModalDismissReasons.BACKDROP_CLICK) {
-      return 'by clicking on a backdrop';
-    } else {
-      return `with: ${reason}`;
-    }
-  }
-
   public getByIdCliente(id: number) {
     this.service.getByIdCliente(id).subscribe((responde) => {
       this.service.selectCliente = responde[0];


### PR DESCRIPTION
## Summary
- remove NgbModal-related imports and constructor injection from gestionar-cliente component
- delete unused closeResult tracking and getDismissReason helper

## Testing
- npx ng lint *(fails: lint target not configured for project)*

------
https://chatgpt.com/codex/tasks/task_e_68daadd567e8833381f3356c1e1f478d