### PR TITLE
Refactor cliente UI to mirror pedidos module

### DIFF
--- a/src/app/control-panel/gestionar-cliente/clientes-common.css
+++ b/src/app/control-panel/gestionar-cliente/clientes-common.css
@@ -1,0 +1,45 @@
+.dashboard-content {
+  padding: 2rem 0;
+}
+
+.dashboard-content h1 {
+  font-size: 2.5rem;
+  font-weight: 600;
+}
+
+.clientes-header .btn {
+  min-width: 180px;
+}
+
+.table-wrapper {
+  background-color: #fff;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+}
+
+.table-wrapper .table {
+  margin-bottom: 0;
+}
+
+.table-wrapper th {
+  font-weight: 600;
+}
+
+.table-wrapper td {
+  vertical-align: middle;
+}
+
+.dashboard-content .card {
+  margin-bottom: 1.5rem;
+}
+
+.dashboard-content .btn {
+  text-transform: none;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: flex-end;
+}

--- a/src/app/control-panel/gestionar-cliente/editar-cliente/editar-cliente.component.html
+++ b/src/app/control-panel/gestionar-cliente/editar-cliente/editar-cliente.component.html
@@ -1,69 +1,60 @@
-<div class="container-fluid dashboard-content ">
-    <div class="row">
-        <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12">
-            <div class="page-header">
-                <h2 class="pageheader-title">Form Validations </h2>
-                <p class="pageheader-text">Proin placerat ante duiullam scelerisque a velit ac porta, fusce sit amet vestibulum mi. Morbi lobortis pulvinar quam.</p>
-                <div class="page-breadcrumb">
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb">
-                            <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Dashboard</a></li>
-                            <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Forms</a></li>
-                            <li class="breadcrumb-item active" aria-current="page">Form Validations</li>
-                        </ol>
-                    </nav>
-                </div>
-            </div>
-        </div>
-    </div>
+<div class="dashboard-ecommerce">
+  <div class="container-fluid dashboard-content">
+    <h1>Editar cliente</h1>
 
     <form #clienteEditarForm="ngForm" (ngSubmit)="editCliente(clienteEditarForm)">
-        <!-- card numero 1 -->
-        <mat-card class="card">
-            <mat-card-header class="card-header">
-                <mat-card-title>Editar Cliente</mat-card-title>
-            </mat-card-header>
-            <mat-card-content class="card-body">
-                <div class="form-row">
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 input-disabled" appearance="fill">
-                        <mat-label>codigoCliente</mat-label>
-                        <input matInput type="text" name="codigoCliente" #codigoCliente="ngModel" [(ngModel)]="service.selectCliente.codigoCliente" [readonly]="true">
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Nombre</mat-label>
-                        <input matInput type="text" name="nombre" #nombre="ngModel" [(ngModel)]="service.selectCliente.nombre" disabled required>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Apellido</mat-label>
-                        <input matInput type="text" name="apellido" #apellido="ngModel" [(ngModel)]="service.selectCliente.apellido" disabled required>
-                    </mat-form-field>
+      <mat-card class="card">
+        <mat-card-header class="card-header">
+          <mat-card-title>Información del cliente</mat-card-title>
+        </mat-card-header>
+        <mat-card-content class="card-body">
+          <div class="form-row">
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 input-disabled" appearance="fill">
+              <mat-label>Código</mat-label>
+              <input matInput type="text" name="codigoCliente" #codigoCliente="ngModel"
+                [(ngModel)]="service.selectCliente.codigoCliente" [readonly]="true">
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Nombre</mat-label>
+              <input matInput type="text" name="nombre" #nombre="ngModel" [(ngModel)]="service.selectCliente.nombre" disabled required>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Apellido</mat-label>
+              <input matInput type="text" name="apellido" #apellido="ngModel" [(ngModel)]="service.selectCliente.apellido" disabled required>
+            </mat-form-field>
 
-                    <mat-form-field appearance="fill" class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2">
-                        <mat-label>Correo</mat-label>
-                        <input matInput type="text" name="correo" #correo="ngModel" [(ngModel)]="service.selectCliente.correo" [pattern]="correoPattern" required>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Número de documento</mat-label>
-                        <input matInput type="text" name="doc" #doc="ngModel" [(ngModel)]="service.selectCliente.doc" disabled required>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Celular</mat-label>
-                        <input matInput type="text" name="celular" #celular="ngModel" [(ngModel)]="service.selectCliente.celular" [pattern]="celularPattern" required>
-                    </mat-form-field>
-                </div>
-                <div class="form-row">
-                    <mat-form-field class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12 mb-12 " appearance="fill">
-                        <mat-label>Dirección</mat-label>
-                        <textarea matInput type="text" name="direccion" #direccion="ngModel" [(ngModel)]="service.selectCliente.direccion" required></textarea>
-                    </mat-form-field>
-                </div>
-            </mat-card-content>
-        </mat-card>
-        <button class="btn btn-primary mb-2 mr-1" type="submit" [disabled]="clienteEditarForm.invalid"> 
-            Actualizar
+            <mat-form-field appearance="fill" class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2">
+              <mat-label>Correo</mat-label>
+              <input matInput type="text" name="correo" #correo="ngModel" [(ngModel)]="service.selectCliente.correo"
+                [pattern]="correoPattern" required>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Número de documento</mat-label>
+              <input matInput type="text" name="doc" #doc="ngModel" [(ngModel)]="service.selectCliente.doc" disabled required>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Celular</mat-label>
+              <input matInput type="text" name="celular" #celular="ngModel" [(ngModel)]="service.selectCliente.celular"
+                [pattern]="celularPattern" required>
+            </mat-form-field>
+          </div>
+          <div class="form-row">
+            <mat-form-field class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Dirección</mat-label>
+              <textarea matInput type="text" name="direccion" #direccion="ngModel"
+                [(ngModel)]="service.selectCliente.direccion" required></textarea>
+            </mat-form-field>
+          </div>
+        </mat-card-content>
+      </mat-card>
+      <div class="form-actions">
+        <button class="btn btn-outline-dark" type="submit" [disabled]="clienteEditarForm.invalid">
+          Actualizar
         </button>
-        <button class="btn btn-primary mb-2 mr-1" type="button" [routerLink]="['/home/gestionar-cliente']"> 
-            atras
+        <button class="btn btn-outline-dark" type="button" [routerLink]="['/home/gestionar-cliente']">
+          Atrás
         </button>
+      </div>
     </form>
+  </div>
 </div>

--- a/src/app/control-panel/gestionar-cliente/editar-cliente/editar-cliente.component.ts
+++ b/src/app/control-panel/gestionar-cliente/editar-cliente/editar-cliente.component.ts
@@ -1,15 +1,12 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { NgForm } from '@angular/forms';
 import { ClienteService } from '../service/cliente.service';
-import { FormGroup, NgForm, NgModel } from '@angular/forms';
-import { MatTableDataSource } from '@angular/material/table';
-import { Cliente } from '../model/cliente.model';
-import { DateAdapter } from '@angular/material/core';
 import swal from 'sweetalert2';
 
 @Component({
   selector: 'app-editar-cliente',
   templateUrl: './editar-cliente.component.html',
-  styleUrls: ['./editar-cliente.component.css']
+  styleUrls: ['./editar-cliente.component.css', '../clientes-common.css']
 })
 export class EditarClienteComponent implements OnInit {
 
@@ -60,11 +57,5 @@ export class EditarClienteComponent implements OnInit {
         });
       }
     );
-  }
-
-
-
-  clear(ClienteForm: NgForm) {
-    ClienteForm.reset();
   }
 }

--- a/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.css
+++ b/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.css
@@ -1,16 +1,14 @@
-.table{
-    width: 100%;
-  }
-
-h1{
-    font-size: 40px;
+.table {
+  width: 100%;
 }
 
-.border-gray{
-  color:gray;
+.action-button {
+  min-width: auto;
+  padding: 0;
+  color: #343a40;
 }
 
-.button-margin{
-  margin-bottom: 20px;
-  float: right;
+.action-button:hover,
+.action-button:focus {
+  background-color: transparent;
 }

--- a/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.html
+++ b/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.html
@@ -1,69 +1,76 @@
 <div class="dashboard-ecommerce">
-    <div class="container-fluid dashboard-content">
-        <h1 class="mb-4">Clientes</h1>
-        <div class="row">
-            <div class="col-6 input-group mb-4 ml-3 p-0 rounded bg-white border border-gray">
-                <input matInput type="search" placeholder="Buscar" (keyup)="applyFilter($event)"
-                    class="form-control bg-transparent pl-2 border-0 shadow-none">
-                <button class="bg-transparent border-0 fa fa-search"></button>
-            </div>
-        </div>
+  <div class="container-fluid dashboard-content">
+    <div class="container-fluid clientes-layout">
+      <div class="clientes-header d-flex flex-wrap justify-content-between align-items-center gap-3 mb-4">
+        <h1 class="mb-0">Clientes</h1>
+        <button class="btn btn-outline-dark btn-lg" [routerLink]="['/home/gestionar-cliente/registrar-cliente']">
+          Registrar cliente
+        </button>
+      </div>
 
-        <div class="row">
-            <div class="col-12">
-                <button class="button-margin" mat-raised-button color="primary"
-                    [routerLink]="['/home/gestionar-cliente/registrar-cliente']">Registrar Cliente</button>
-            </div>
+      <div class="row mb-4">
+        <div class="col-12 col-lg-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <input matInput type="search" placeholder="Buscar" autocomplete="off" (keyup)="applyFilter($event)">
+          </mat-form-field>
         </div>
-        <div class="shadow">
-            <div class="table-responsive">
-                <table mat-table [dataSource]="dataSource" matSort class="table">
-                    <ng-container matColumnDef="codigoCliente">
-                        <div class="text-center">
-                            <th mat-header-cell *matHeaderCellDef mat-sort-header>ID</th>
-                        </div>
-                        <td mat-cell *matCellDef="let element"> {{element.codigoCliente}} </td>
-                    </ng-container>
-                    <ng-container matColumnDef="nombre">
-                        <th mat-header-cell *matHeaderCellDef mat-sort-header>Nombre</th>
-                        <td mat-cell *matCellDef="let element"> {{element.nombre}} </td>
-                    </ng-container>
-                    <ng-container matColumnDef="apellido">
-                        <th mat-header-cell *matHeaderCellDef mat-sort-header>Apellido</th>
-                        <td mat-cell *matCellDef="let element"> {{element.apellido}} </td>
-                    </ng-container>
-                    <ng-container matColumnDef="correo">
-                        <th mat-header-cell *matHeaderCellDef mat-sort-header>Correo</th>
-                        <td mat-cell *matCellDef="let element">{{element.correo}}</td>
-                    </ng-container>
-                    <ng-container matColumnDef="celular">
-                        <th mat-header-cell *matHeaderCellDef mat-sort-header>Celular</th>
-                        <td mat-cell *matCellDef="let element">{{element.celular}}</td>
-                    </ng-container>
-                    <ng-container matColumnDef="doc">
-                        <th mat-header-cell *matHeaderCellDef mat-sort-header>Número de documento</th>
-                        <td mat-cell *matCellDef="let element">{{element.doc}}</td>
-                    </ng-container>
-                    <ng-container matColumnDef="direccion">
-                        <th mat-header-cell *matHeaderCellDef mat-sort-header>Direccion</th>
-                        <td mat-cell *matCellDef="let element">{{element.direccion}}</td>
-                    </ng-container>
-                    <ng-container matColumnDef="actions">
-                        <th mat-header-cell *matHeaderCellDef mat-sort-header> Acciones </th>
-                        <td mat-cell *matCellDef="let element">
-                            <button mat-raised-button color="primary" (click)="getByIdCliente(element.idCliente)" [routerLink]="['/home/gestionar-cliente/editar-cliente']">
+      </div>
 
-                                <span class="fas fa-edit"></span>
-                            </button>
-                        </td>
-                    </ng-container>
+      <div class="table-wrapper shadow-sm">
+        <div class="table-responsive">
+          <table mat-table [dataSource]="dataSource" matSort class="table">
+            <ng-container matColumnDef="codigoCliente">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header class="text-uppercase">ID</th>
+              <td mat-cell *matCellDef="let element">{{ element.codigoCliente }}</td>
+            </ng-container>
 
-                    <tr mat-header-row *matHeaderRowDef="displayedColumns2"></tr>
-                    <tr mat-row *matRowDef="let row; columns: displayedColumns2;"></tr>
-                </table>
-                <mat-paginator #paginator [pageSize]="25" [pageSizeOptions]="[10, 25, 100]">
-                </mat-paginator>
-            </div>
+            <ng-container matColumnDef="nombre">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Nombre</th>
+              <td mat-cell *matCellDef="let element">{{ element.nombre }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="apellido">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Apellido</th>
+              <td mat-cell *matCellDef="let element">{{ element.apellido }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="correo">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Correo</th>
+              <td mat-cell *matCellDef="let element">{{ element.correo }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="celular">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Celular</th>
+              <td mat-cell *matCellDef="let element">{{ element.celular }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="doc">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Número de documento</th>
+              <td mat-cell *matCellDef="let element">{{ element.doc }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="direccion">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Dirección</th>
+              <td mat-cell *matCellDef="let element">{{ element.direccion }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="actions">
+              <th mat-header-cell *matHeaderCellDef>Acciones</th>
+              <td mat-cell *matCellDef="let element" class="text-nowrap">
+                <button mat-button class="action-button"
+                        (click)="getByIdCliente(element.idCliente)"
+                        [routerLink]="['/home/gestionar-cliente/editar-cliente']">
+                  <i class="fas fa-edit fa-2x"></i>
+                </button>
+              </td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="displayedColumns2"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns2;"></tr>
+          </table>
         </div>
+        <mat-paginator #paginator [pageSize]="25" [pageSizeOptions]="[10, 25, 100]"></mat-paginator>
+      </div>
     </div>
+  </div>
 </div>

--- a/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.ts
+++ b/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
@@ -7,7 +7,7 @@ import { ClienteService } from './service/cliente.service';
 @Component({
   selector: 'app-gestionar-cliente',
   templateUrl: './gestionar-cliente.component.html',
-  styleUrls: ['./gestionar-cliente.component.css']
+  styleUrls: ['./gestionar-cliente.component.css', './clientes-common.css']
 })
 export class GestionarClienteComponent implements OnInit {
 

--- a/src/app/control-panel/gestionar-cliente/registrar-cliente/registrar-cliente.component.html
+++ b/src/app/control-panel/gestionar-cliente/registrar-cliente/registrar-cliente.component.html
@@ -1,101 +1,88 @@
-<div class="container-fluid dashboard-content ">
-    <div class="row">
-        <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12">
-            <div class="page-header">
-                <h2 class="pageheader-title">Form Validations </h2>
-                <p class="pageheader-text">Proin placerat ante duiullam scelerisque a velit ac porta, fusce sit amet vestibulum mi. Morbi lobortis pulvinar quam.</p>
-                <div class="page-breadcrumb">
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb">
-                            <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Dashboard</a></li>
-                            <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Forms</a></li>
-                            <li class="breadcrumb-item active" aria-current="page">Form Validations</li>
-                        </ol>
-                    </nav>
-                </div>
-            </div>
-        </div>
-    </div>
+<div class="dashboard-ecommerce">
+  <div class="container-fluid dashboard-content">
+    <h1>Registrar cliente</h1>
 
     <form #clienteForm="ngForm" (ngSubmit)="addCliente(clienteForm)">
-        <!-- card numero 1 -->
-        <mat-card class="card">
-            <mat-card-header class="card-header">
-                <mat-card-title>Registrar Cliente</mat-card-title>
-            </mat-card-header>
-            <mat-card-content class="card-body">
-                <div class="form-row">
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Nombre</mat-label>
-                        <input matInput type="text" name="nombre" #nombre="ngModel" ngModel [pattern]="nombrePattern" required>
-                        <div *ngIf="nombre.errors?.pattern">
-                            <p>*Sólo letras</p>
-                        </div>
-                        <div *ngIf="nombre.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Apellido</mat-label>
-                        <input matInput type="text" name="apellido" #apellido="ngModel" ngModel [pattern]="apellidoPattern" required>
-                        <div *ngIf="apellido.errors?.pattern">
-                            <p>*Sólo letras</p>
-                        </div>
-                        <div *ngIf="apellido.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
+      <mat-card class="card">
+        <mat-card-header class="card-header">
+          <mat-card-title>Información del cliente</mat-card-title>
+        </mat-card-header>
+        <mat-card-content class="card-body">
+          <div class="form-row">
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Nombre</mat-label>
+              <input matInput type="text" name="nombre" #nombre="ngModel" ngModel [pattern]="nombrePattern" required>
+              <div *ngIf="nombre.errors?.pattern">
+                <p>*Sólo letras</p>
+              </div>
+              <div *ngIf="nombre.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Apellido</mat-label>
+              <input matInput type="text" name="apellido" #apellido="ngModel" ngModel [pattern]="apellidoPattern" required>
+              <div *ngIf="apellido.errors?.pattern">
+                <p>*Sólo letras</p>
+              </div>
+              <div *ngIf="apellido.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
 
-                    <mat-form-field appearance="fill" class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2">
-                        <mat-label>Correo</mat-label>
-                        <input matInput type="text" name="correo" #correo="ngModel" ngModel [pattern]="correoPattern" required>
-                        <div *ngIf="correo.errors?.pattern">
-                            <p>*Ingrese un email correcto</p>
-                        </div>
-                        <div *ngIf="correo.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Número de documento</mat-label>
-                        <input matInput type="text" name="doc" #doc="ngModel" ngModel [pattern]="docPattern" required>
-                        <div *ngIf="doc.errors?.pattern">
-                            <p>*Sólo números</p>
-                        </div>
-                        <div *ngIf="doc.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Celular</mat-label>
-                        <input matInput type="text" name="celular" #celular="ngModel" ngModel [pattern]="celularPattern" required>
-                        <div *ngIf="celular.errors?.pattern">
-                            <p>*Sólo números</p>
-                        </div>
-                        <div *ngIf="celular.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
-                </div>
-                <div class="form-row">
-                    <mat-form-field class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12 mb-12 " appearance="fill">
-                        <mat-label>Dirección</mat-label>
-                        <textarea matInput type="text" name="direccion" #direccion="ngModel" ngModel required></textarea>
-                        <div *ngIf="direccion.errors?.pattern">
-                            <p>*Ingrese una dirección correcta</p>
-                        </div>
-                        <div *ngIf="direccion.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
-                </div>
-            </mat-card-content>
-        </mat-card>
-        <button class="btn btn-primary mb-2 mr-1" type="submit" [disabled]="clienteForm.invalid"> 
-            Registrar
+            <mat-form-field appearance="fill" class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2">
+              <mat-label>Correo</mat-label>
+              <input matInput type="text" name="correo" #correo="ngModel" ngModel [pattern]="correoPattern" required>
+              <div *ngIf="correo.errors?.pattern">
+                <p>*Ingrese un email correcto</p>
+              </div>
+              <div *ngIf="correo.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Número de documento</mat-label>
+              <input matInput type="text" name="doc" #doc="ngModel" ngModel [pattern]="docPattern" required>
+              <div *ngIf="doc.errors?.pattern">
+                <p>*Sólo números</p>
+              </div>
+              <div *ngIf="doc.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Celular</mat-label>
+              <input matInput type="text" name="celular" #celular="ngModel" ngModel [pattern]="celularPattern" required>
+              <div *ngIf="celular.errors?.pattern">
+                <p>*Sólo números</p>
+              </div>
+              <div *ngIf="celular.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
+          </div>
+          <div class="form-row">
+            <mat-form-field class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Dirección</mat-label>
+              <textarea matInput type="text" name="direccion" #direccion="ngModel" ngModel required></textarea>
+              <div *ngIf="direccion.errors?.pattern">
+                <p>*Ingrese una dirección correcta</p>
+              </div>
+              <div *ngIf="direccion.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
+          </div>
+        </mat-card-content>
+      </mat-card>
+      <div class="form-actions">
+        <button class="btn btn-outline-dark" type="submit" [disabled]="clienteForm.invalid">
+          Registrar
         </button>
-        <button class="btn btn-primary mb-2 mr-1" type="button" [routerLink]="['/home/gestionar-cliente']"> 
-            atras
+        <button class="btn btn-outline-dark" type="button" [routerLink]="['/home/gestionar-cliente']">
+          Atrás
         </button>
+      </div>
     </form>
+  </div>
 </div>

--- a/src/app/control-panel/gestionar-cliente/registrar-cliente/registrar-cliente.component.ts
+++ b/src/app/control-panel/gestionar-cliente/registrar-cliente/registrar-cliente.component.ts
@@ -1,15 +1,12 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { NgForm } from '@angular/forms';
 import { ClienteService } from '../service/cliente.service';
-import { FormGroup, NgForm, NgModel } from '@angular/forms';
-import { MatTableDataSource } from '@angular/material/table';
-import { Cliente } from '../model/cliente.model';
-import { DateAdapter } from '@angular/material/core';
 import swal from 'sweetalert2';
 
 @Component({
   selector: 'app-registrar-cliente',
   templateUrl: './registrar-cliente.component.html',
-  styleUrls: ['./registrar-cliente.component.css']
+  styleUrls: ['./registrar-cliente.component.css', '../clientes-common.css']
 })
 export class RegistrarClienteComponent implements OnInit {
 

--- a/src/app/control-panel/gestionar-pedido/gestionar-pedido.component.html
+++ b/src/app/control-panel/gestionar-pedido/gestionar-pedido.component.html
@@ -10,7 +10,7 @@
       </div>
       <div class="col-4">
         <div style="text-align:right">
-          <button class="btn btn-primary btn-lg" [routerLink]="['/home/gestionar-pedido/agregar']">
+          <button class="btn btn-outline-dark btn-lg" [routerLink]="['/home/gestionar-pedido/agregar']">
             Registrar pedido
           </button>
         </div>


### PR DESCRIPTION
## Summary
- restyle the cliente list to mirror the pedidos layout with shared header, search field, and table action styling
- refresh the registrar and editar cliente forms with matching headings, card copy, and shared button treatment
- update the gestionar pedido CTA button to share the outline styling used across the pedidos module

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daafab35fc8333be69d11ae7d4528e